### PR TITLE
Update date bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	},
 	"name": "timeseries-analysis",
 	"description": "timeseries-analysis",
-	"version": "1.0.12",
+	"version": "1.0.13",
 	"homepage": "https://github.com/26medias/timeseries-analysis",
 	"licenses": [
 		{
@@ -31,6 +31,6 @@
 	"bugs": {
 		"url": "https://github.com/26medias/timeseries-analysis/issues"
 	},
-	"_id": "timeseries-analysis@1.0.12",
+	"_id": "timeseries-analysis@1.0.13",
 	"_from": "timeseries-analysis@latest"
 }


### PR DESCRIPTION
What I did:
- Remove unused library.
- Change regression_forecast method from using date class operator overloading to the basic method.
- Add data options to the regression_forecast method.

What I found:
- I think this code below in the regression_forecast method should be fixed. Because when the sample is defined and not the same as real data, it should not see another data except the sample right? and should not calculate from that too.
```
var mean = this.mean(options.data);
```